### PR TITLE
M2-T4: Implement Dealer AI Logic

### DIFF
--- a/src/engine/__tests__/dealer.test.ts
+++ b/src/engine/__tests__/dealer.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect } from 'vitest';
+import { shouldDealerHit, playDealerHand } from '../dealer';
+import type { Card, Rank, Suit } from '../../types';
+import type { DealerRules } from '../dealer';
+
+const createCard = (rank: string, suit: string = '♠'): Card => ({
+  rank: rank as Rank,
+  suit: suit as Suit,
+  faceUp: true,
+});
+
+describe('Dealer AI Logic', () => {
+  describe('shouldDealerHit', () => {
+    const standardRules: DealerRules = { hitOnSoft17: false };
+    const casinoRules: DealerRules = { hitOnSoft17: true };
+
+    describe('with standard rules (stand on soft 17)', () => {
+      it('should hit on 16 or less', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('6')], standardRules)).toBe(true);
+        expect(shouldDealerHit([createCard('9'), createCard('7')], standardRules)).toBe(true);
+        expect(shouldDealerHit([createCard('5'), createCard('5'), createCard('5')], standardRules)).toBe(true);
+      });
+
+      it('should stand on hard 17 or more', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('7')], standardRules)).toBe(false);
+        expect(shouldDealerHit([createCard('10'), createCard('10')], standardRules)).toBe(false);
+        expect(shouldDealerHit([createCard('9'), createCard('9')], standardRules)).toBe(false);
+      });
+
+      it('should stand on soft 17 (A-6)', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('6')], standardRules)).toBe(false);
+      });
+
+      it('should stand on soft 18 or higher', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('7')], standardRules)).toBe(false);
+        expect(shouldDealerHit([createCard('A'), createCard('8')], standardRules)).toBe(false);
+      });
+
+      it('should hit on soft hands less than 17', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('5')], standardRules)).toBe(true);
+        expect(shouldDealerHit([createCard('A'), createCard('4')], standardRules)).toBe(true);
+      });
+
+      it('should stand when bust', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('Q'), createCard('5')], standardRules)).toBe(false);
+      });
+    });
+
+    describe('with casino rules (hit on soft 17)', () => {
+      it('should hit on 16 or less', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('6')], casinoRules)).toBe(true);
+        expect(shouldDealerHit([createCard('9'), createCard('7')], casinoRules)).toBe(true);
+      });
+
+      it('should stand on hard 17 or more', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('7')], casinoRules)).toBe(false);
+        expect(shouldDealerHit([createCard('10'), createCard('10')], casinoRules)).toBe(false);
+      });
+
+      it('should HIT on soft 17 (A-6)', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('6')], casinoRules)).toBe(true);
+      });
+
+      it('should stand on soft 18 or higher', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('7')], casinoRules)).toBe(false);
+        expect(shouldDealerHit([createCard('A'), createCard('8')], casinoRules)).toBe(false);
+      });
+
+      it('should stand when bust', () => {
+        expect(shouldDealerHit([createCard('K'), createCard('Q'), createCard('5')], casinoRules)).toBe(false);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle empty hand', () => {
+        expect(shouldDealerHit([], standardRules)).toBe(true);
+      });
+
+      it('should handle single card', () => {
+        expect(shouldDealerHit([createCard('5')], standardRules)).toBe(true);
+        expect(shouldDealerHit([createCard('K')], standardRules)).toBe(true);
+      });
+
+      it('should handle multiple aces', () => {
+        // A-A-5 = 17 (soft)
+        expect(shouldDealerHit([createCard('A'), createCard('A'), createCard('5')], standardRules)).toBe(false);
+        // A-A-5 = 17 (soft) with hit on soft 17
+        expect(shouldDealerHit([createCard('A'), createCard('A'), createCard('5')], casinoRules)).toBe(true);
+      });
+
+      it('should handle blackjack (should stand)', () => {
+        expect(shouldDealerHit([createCard('A'), createCard('K')], standardRules)).toBe(false);
+        expect(shouldDealerHit([createCard('A'), createCard('K')], casinoRules)).toBe(false);
+      });
+    });
+  });
+
+  describe('playDealerHand', () => {
+    const standardRules: DealerRules = { hitOnSoft17: false };
+    const casinoRules: DealerRules = { hitOnSoft17: true };
+
+    describe('automated play sequence', () => {
+      it('should play out dealer hand until stand', () => {
+        const initialCards = [createCard('K'), createCard('6')]; // 16
+        const availableCards = [
+          createCard('5'), // will make 21
+        ];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.finalCards).toHaveLength(3);
+        expect(result.finalCards[2].rank).toBe('5');
+        expect(result.decisions).toHaveLength(2); // hit decision, then stand decision
+        expect(result.decisions[0].action).toBe('hit');
+        expect(result.decisions[1].action).toBe('stand');
+      });
+
+      it('should stand on 17 immediately', () => {
+        const initialCards = [createCard('K'), createCard('7')]; // 17
+        const availableCards = [createCard('5')];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.finalCards).toHaveLength(2);
+        expect(result.decisions).toHaveLength(1);
+        expect(result.decisions[0].action).toBe('stand');
+      });
+
+      it('should hit until bust', () => {
+        const initialCards = [createCard('K'), createCard('6')]; // 16
+        const availableCards = [
+          createCard('K'), // 26 - bust
+        ];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.finalCards).toHaveLength(3);
+        expect(result.decisions).toHaveLength(2);
+        expect(result.decisions[0].action).toBe('hit');
+        expect(result.decisions[1].action).toBe('stand');
+        expect(result.decisions[1].reason).toContain('bust');
+      });
+
+      it('should handle multiple hits', () => {
+        const initialCards = [createCard('2'), createCard('3')]; // 5
+        const availableCards = [
+          createCard('4'), // 9
+          createCard('5'), // 14
+          createCard('6'), // 20
+        ];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.finalCards).toHaveLength(5);
+        expect(result.decisions).toHaveLength(4); // 3 hits + 1 stand
+        expect(result.decisions.filter(d => d.action === 'hit')).toHaveLength(3);
+        expect(result.decisions[3].action).toBe('stand');
+      });
+    });
+
+    describe('soft 17 rule variations', () => {
+      it('should stand on soft 17 with standard rules', () => {
+        const initialCards = [createCard('A'), createCard('6')]; // soft 17
+        const availableCards = [createCard('5')];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.finalCards).toHaveLength(2);
+        expect(result.decisions).toHaveLength(1);
+        expect(result.decisions[0].action).toBe('stand');
+        expect(result.decisions[0].isSoft).toBe(true);
+      });
+
+      it('should hit on soft 17 with casino rules', () => {
+        const initialCards = [createCard('A'), createCard('6')]; // soft 17
+        const availableCards = [createCard('3')]; // makes 20
+
+        const result = playDealerHand(initialCards, availableCards, casinoRules);
+
+        expect(result.finalCards).toHaveLength(3);
+        expect(result.decisions).toHaveLength(2);
+        expect(result.decisions[0].action).toBe('hit');
+        expect(result.decisions[0].isSoft).toBe(true);
+        expect(result.decisions[1].action).toBe('stand');
+      });
+    });
+
+    describe('decision logging', () => {
+      it('should log all decisions with correct metadata', () => {
+        const initialCards = [createCard('K'), createCard('6')]; // 16
+        const availableCards = [createCard('5')]; // makes 21
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        // First decision: hit on 16
+        expect(result.decisions[0]).toMatchObject({
+          action: 'hit',
+          handValue: 16,
+          isSoft: false,
+        });
+        expect(result.decisions[0].reason).toBeTruthy();
+
+        // Second decision: stand on 21
+        expect(result.decisions[1]).toMatchObject({
+          action: 'stand',
+          handValue: 21,
+          isSoft: false,
+        });
+        expect(result.decisions[1].reason).toBeTruthy();
+      });
+
+      it('should indicate soft hands in decision log', () => {
+        const initialCards = [createCard('A'), createCard('5')]; // soft 16
+        const availableCards = [
+          createCard('K'), // makes hard 16
+          createCard('5'), // makes 21
+        ];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        expect(result.decisions[0].isSoft).toBe(true);
+        expect(result.decisions[0].handValue).toBe(16);
+      });
+
+      it('should log reason for standing', () => {
+        const initialCards = [createCard('K'), createCard('8')]; // 18
+
+        const result = playDealerHand(initialCards, [], standardRules);
+
+        expect(result.decisions[0].reason).toContain('17');
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle blackjack (immediate stand)', () => {
+        const initialCards = [createCard('A'), createCard('K')]; // 21
+
+        const result = playDealerHand(initialCards, [], standardRules);
+
+        expect(result.finalCards).toHaveLength(2);
+        expect(result.decisions).toHaveLength(1);
+        expect(result.decisions[0].action).toBe('stand');
+      });
+
+      it('should throw error if not enough cards to complete hand', () => {
+        const initialCards = [createCard('2'), createCard('3')]; // 5
+        const availableCards: Card[] = []; // no cards to draw
+
+        expect(() => playDealerHand(initialCards, availableCards, standardRules)).toThrow();
+      });
+
+      it('should handle complex soft/hard transitions', () => {
+        const initialCards = [createCard('A'), createCard('5')]; // soft 16
+        const availableCards = [
+          createCard('A'), // soft 17 - will stand with standard rules
+        ];
+
+        const result = playDealerHand(initialCards, availableCards, standardRules);
+
+        // With standard rules (stand on soft 17), dealer should:
+        // 1. Hit on soft 16
+        // 2. Stand on soft 17
+        expect(result.finalCards).toHaveLength(3);
+        expect(result.decisions).toHaveLength(2);
+        expect(result.decisions[0].isSoft).toBe(true);
+        expect(result.decisions[0].action).toBe('hit');
+        expect(result.decisions[1].isSoft).toBe(true);
+        expect(result.decisions[1].action).toBe('stand');
+      });
+    });
+  });
+});

--- a/src/engine/dealer.ts
+++ b/src/engine/dealer.ts
@@ -1,0 +1,193 @@
+import type { Card } from '../types';
+import { evaluateHand } from './hand';
+
+/**
+ * Configuration rules for dealer behavior
+ */
+export interface DealerRules {
+  /**
+   * Whether dealer should hit on soft 17
+   * - false: Stand on soft 17 (standard/player-friendly rule)
+   * - true: Hit on soft 17 (house-favorable rule, common in many casinos)
+   */
+  hitOnSoft17: boolean;
+}
+
+/**
+ * Represents a single decision made by the dealer AI
+ * Used for debugging and game transparency
+ */
+export interface DealerDecision {
+  /**
+   * The action taken by the dealer
+   */
+  action: 'hit' | 'stand';
+
+  /**
+   * The hand value at the time of decision
+   */
+  handValue: number;
+
+  /**
+   * Whether the hand was soft (contains an Ace counted as 11)
+   */
+  isSoft: boolean;
+
+  /**
+   * Human-readable reason for the decision
+   */
+  reason: string;
+}
+
+/**
+ * Result of dealer's automated play sequence
+ */
+export interface DealerPlayResult {
+  /**
+   * The final cards in the dealer's hand after playing
+   */
+  finalCards: Card[];
+
+  /**
+   * Log of all decisions made during play
+   */
+  decisions: DealerDecision[];
+}
+
+/**
+ * Determine if the dealer should hit based on their current hand and rules
+ *
+ * @param cards - The dealer's current cards
+ * @param rules - The dealer rules configuration
+ * @returns true if dealer should hit, false if dealer should stand
+ *
+ * @example
+ * ```ts
+ * const cards = [{ rank: 'K', suit: '♠', faceUp: true }, { rank: '6', suit: '♥', faceUp: true }];
+ * const rules = { hitOnSoft17: false };
+ * shouldDealerHit(cards, rules); // true (16 < 17)
+ * ```
+ */
+export function shouldDealerHit(cards: Card[], rules: DealerRules): boolean {
+  // Handle empty hand (should always hit)
+  if (cards.length === 0) {
+    return true;
+  }
+
+  const handValue = evaluateHand(cards);
+
+  // Always stand on bust
+  if (handValue.isBust) {
+    return false;
+  }
+
+  // Always stand on blackjack
+  if (handValue.isBlackjack) {
+    return false;
+  }
+
+  // Hit on anything less than 17
+  if (handValue.value < 17) {
+    return true;
+  }
+
+  // Stand on hard 17 or higher
+  if (handValue.value >= 17 && !handValue.isSoft) {
+    return false;
+  }
+
+  // Soft 17 - depends on rules
+  if (handValue.value === 17 && handValue.isSoft) {
+    return rules.hitOnSoft17;
+  }
+
+  // Soft 18+ - always stand
+  if (handValue.value >= 18 && handValue.isSoft) {
+    return false;
+  }
+
+  // Default: stand
+  return false;
+}
+
+/**
+ * Play out the dealer's hand automatically according to blackjack rules
+ *
+ * The dealer will:
+ * 1. Hit if hand value is less than 17
+ * 2. Hit or stand on soft 17 based on rules
+ * 3. Stand on hard 17 or higher
+ * 4. Stand when bust
+ *
+ * @param initialCards - The dealer's starting cards
+ * @param availableCards - Cards available to draw from (typically the deck)
+ * @param rules - The dealer rules configuration
+ * @returns Result containing final cards and decision log
+ * @throws Error if not enough cards available to complete the hand
+ *
+ * @example
+ * ```ts
+ * const initialCards = [
+ *   { rank: 'K', suit: '♠', faceUp: true },
+ *   { rank: '6', suit: '♥', faceUp: true }
+ * ];
+ * const deck = [...]; // remaining cards
+ * const rules = { hitOnSoft17: false };
+ *
+ * const result = playDealerHand(initialCards, deck, rules);
+ * console.log(result.finalCards); // Dealer's final hand
+ * console.log(result.decisions);  // All decisions made
+ * ```
+ */
+export function playDealerHand(
+  initialCards: Card[],
+  availableCards: Card[],
+  rules: DealerRules
+): DealerPlayResult {
+  const decisions: DealerDecision[] = [];
+  let currentCards = [...initialCards];
+  let cardIndex = 0;
+
+  // Play until dealer must stand
+  while (shouldDealerHit(currentCards, rules)) {
+    const handValue = evaluateHand(currentCards);
+
+    // Log the hit decision
+    decisions.push({
+      action: 'hit',
+      handValue: handValue.value,
+      isSoft: handValue.isSoft,
+      reason: `Hand value ${handValue.value}${handValue.isSoft ? ' (soft)' : ''} is less than ${
+        handValue.isSoft && handValue.value === 17 && rules.hitOnSoft17 ? '18 (hitting on soft 17)' : '17'
+      }`,
+    });
+
+    // Check if we have cards available
+    if (cardIndex >= availableCards.length) {
+      throw new Error(
+        `Not enough cards available to complete dealer hand. Needed at least ${cardIndex + 1} cards, but only ${availableCards.length} available.`
+      );
+    }
+
+    // Draw the next card
+    const newCard = availableCards[cardIndex];
+    currentCards = [...currentCards, newCard];
+    cardIndex++;
+  }
+
+  // Log the final stand decision
+  const finalHandValue = evaluateHand(currentCards);
+  decisions.push({
+    action: 'stand',
+    handValue: finalHandValue.value,
+    isSoft: finalHandValue.isSoft,
+    reason: finalHandValue.isBust
+      ? `Hand is bust (${finalHandValue.value})`
+      : `Hand value ${finalHandValue.value}${finalHandValue.isSoft ? ' (soft)' : ''} is 17 or higher`,
+  });
+
+  return {
+    finalCards: currentCards,
+    decisions,
+  };
+}


### PR DESCRIPTION
## Summary
Create the dealer AI logic following standard blackjack rules (dealer stands on 17).

## Tasks
- [x] Implement dealer hit/stand logic (stand on 17+)
- [x] Add soft 17 rule handling (optional)
- [x] Create dealer play automation
- [x] Add decision logging for debugging
- [x] Handle edge cases (bust, blackjack)
- [x] Write comprehensive unit tests

## Technical Details
### Dealer Rules
- Hit on 16 or less
- Stand on 17 or more
- Soft 17 rule variant (some casinos require hit)
- No decisions required - deterministic play

### Decision Logic
```
while dealerValue < 17:
    hit()
return dealerHand
```

## Files Changed
- `src/engine/dealer.ts` - New dealer AI module
- `src/engine/__tests__/dealer.test.ts` - Tests

## Related
- Milestone: M2 - Game Engine
- Task ID: M2-T4
- Priority: Critical
- Depends on: M2-T1, M2-T3
- Follows: [AGENT_PROMPT_M2.md](../docs/AGENT_PROMPT_M2.md)

## Checklist
- [ ] All test cases pass (>80% coverage)
- [ ] Deterministic behavior verified
- [ ] Soft 17 rule configurable
- [ ] Type safety enforced
- [ ] JSDoc documentation complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)