### PR TITLE
Fix Chip selection styling and TypeScript deprecation warning

### DIFF
--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -37,7 +37,7 @@ export function Chip({ value, selected = false, onClick, disabled = false, class
         ${disabled ? 'opacity-50 cursor-not-allowed grayscale' : 'cursor-pointer hover:shadow-glow-gold'}
         ${className}
       `}
-      style={selected ? { ringColor: 'var(--gold)' } : {}}
+      style={selected ? { boxShadow: '0 0 0 4px var(--gold)' } : {}}
     >
       {/* Inner highlight */}
       <div className="absolute inset-0 rounded-full bg-gradient-to-b from-white/20 to-transparent" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
-    "ignoreDeprecations": "6.0",
 
     /* Bundler mode */
     "moduleResolution": "bundler",


### PR DESCRIPTION
## Summary
This PR addresses two issues: fixes the visual styling of selected Chip components and removes a deprecated TypeScript configuration option.

## Key Changes
- **Chip selection styling**: Changed from using `ringColor` style property to `boxShadow` with a 4px gold glow effect. The `ringColor` property is not a valid CSS style and was not producing the intended visual effect.
- **TypeScript config**: Removed the deprecated `ignoreDeprecations: "6.0"` option from `tsconfig.json` to align with current TypeScript best practices and eliminate compiler warnings.

## Implementation Details
The Chip component now uses a standard CSS `boxShadow` property to create the selection indicator, which provides better browser compatibility and more predictable styling behavior compared to the non-standard `ringColor` approach.

https://claude.ai/code/session_01MtgUbXghBN6HbSRe9qWEkn